### PR TITLE
Add basic procedural environment generator

### DIFF
--- a/Assets/Prefabs/GrassTile.prefab
+++ b/Assets/Prefabs/GrassTile.prefab
@@ -1,0 +1,5 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: GrassTile

--- a/Assets/Prefabs/RockTile.prefab
+++ b/Assets/Prefabs/RockTile.prefab
@@ -1,0 +1,5 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: RockTile

--- a/Assets/Scripts/EnvironmentGenerator.cs
+++ b/Assets/Scripts/EnvironmentGenerator.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class EnvironmentGenerator : MonoBehaviour
+{
+    public Vector2Int gridSize = new Vector2Int(10, 10);
+    public TileData[] tiles;
+    public float noiseScale = 0.3f;
+    public int seed;
+    public Transform parent;
+
+    public void Generate()
+    {
+        if (parent == null)
+        {
+            parent = transform;
+        }
+        Random.InitState(seed);
+        for (int x = 0; x < gridSize.x; x++)
+        {
+            for (int y = 0; y < gridSize.y; y++)
+            {
+                float noise = Mathf.PerlinNoise((x + seed) * noiseScale, (y + seed) * noiseScale);
+                int index = Mathf.RoundToInt(noise * (tiles.Length - 1));
+                index = Mathf.Clamp(index, 0, tiles.Length - 1);
+                TileData data = tiles[index];
+                Vector3 position = new Vector3(x, 0, y);
+                if (data != null && data.prefab != null)
+                {
+                    GameObject obj = Instantiate(data.prefab, position, Quaternion.identity, parent);
+                    Tile tileComponent = obj.GetComponent<Tile>();
+                    if (tileComponent == null)
+                    {
+                        tileComponent = obj.AddComponent<Tile>();
+                    }
+                    tileComponent.data = data;
+                    obj.name = $"{data.name}_{x}_{y}";
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Tile.cs
+++ b/Assets/Scripts/Tile.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class Tile : MonoBehaviour
+{
+    public TileData data;
+}

--- a/Assets/Scripts/TileData.cs
+++ b/Assets/Scripts/TileData.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+[CreateAssetMenu(menuName = "Environment/Tile Data")]
+public class TileData : ScriptableObject
+{
+    public GameObject prefab;
+    public TerrainType terrainType;
+    public List<TileData> allowedNeighbors;
+}
+
+public enum TerrainType
+{
+    Grass,
+    Rock,
+    Forest,
+    Mountain
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # peak-ascent
-A fun little project to create a game using vibe code
+
+This project demonstrates a basic procedural environment generation system built in Unity.
+
+## Overview
+
+* `TileData` – ScriptableObject defining individual tile prefabs and metadata.
+* `Tile` – MonoBehaviour holding a reference to its `TileData`.
+* `EnvironmentGenerator` – spawns a grid of tiles using Perlin noise.
+
+Run the generator in Play Mode to create a simple landscape of grass and rock tiles. A sample PlayMode test is included under `Tests/PlayMode` which verifies tile generation for a given seed.

--- a/Tests/PlayMode/EnvironmentGeneratorTests.cs
+++ b/Tests/PlayMode/EnvironmentGeneratorTests.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using System.Collections;
+
+public class EnvironmentGeneratorTests
+{
+    [UnityTest]
+    public IEnumerator GeneratesExpectedTileCount()
+    {
+        var generatorGameObject = new GameObject("Generator");
+        var generator = generatorGameObject.AddComponent<EnvironmentGenerator>();
+        generator.gridSize = new Vector2Int(5, 5);
+        generator.tiles = new TileData[1];
+        generator.seed = 42;
+
+        generator.Generate();
+
+        yield return null;
+
+        int tileCount = generatorGameObject.transform.childCount;
+        Assert.AreEqual(generator.gridSize.x * generator.gridSize.y, tileCount);
+    }
+}


### PR DESCRIPTION
## Summary
- add tile ScriptableObject and Tile component
- implement EnvironmentGenerator for tile-based map spawning
- add placeholder prefab assets
- create a simple PlayMode test
- update README

## Testing
- `dotnet test` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_687df15eaf2c8326a0ed56d429dd3c28